### PR TITLE
Tag `Error` enum as `non_exhaustive` 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Could not connect to LoLA socket")]
     NoLoLAConnection,


### PR DESCRIPTION
This fixes potential future semver issues (https://github.com/IntelligentRoboticsLab/nidhogg/issues/10)