### PR TITLE
Introduce `JointArrayBuilder::from_joint_array` function

### DIFF
--- a/nidhogg/src/types.rs
+++ b/nidhogg/src/types.rs
@@ -711,6 +711,7 @@ pub struct ArmJoints<T> {
 }
 
 impl<T> JointArrayBuilder<T> {
+    /// Set all the joint values to the corresponding values from the provided [`JointArray`].
     pub fn from_joint_array(mut self, joints: JointArray<T>) {
         self.head_pitch = Some(joints.head_pitch);
         self.head_yaw = Some(joints.head_yaw);


### PR DESCRIPTION
Function to build a new joints array from another joints array.