### PR TITLE
Use `std::result::Result` over `miette::Result`

### DIFF
--- a/nidhogg/src/error.rs
+++ b/nidhogg/src/error.rs
@@ -1,7 +1,7 @@
 use miette::Diagnostic;
 use thiserror::Error;
 
-pub type Result<T> = miette::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, Diagnostic, Debug)]
 #[non_exhaustive]


### PR DESCRIPTION
Per miette [readme](https://github.com/zkat/miette?tab=readme-ov-file#-in-libraries):
> Then, return this error type from all your fallible public APIs. It's a best practice to wrap any "external" error types in your error enum instead of using something like [Report](https://docs.rs/miette/latest/miette/struct.Report.html) in a library.