### PR TITLE
Fix coppelia dependency

### DIFF
--- a/nidhogg/Cargo.toml
+++ b/nidhogg/Cargo.toml
@@ -12,8 +12,7 @@ thiserror = "1.0.38"
 miette = { version = "5.10.0" }
 tracing = "0.1.37"
 nidhogg_derive = { workspace = true }
-zmq_remote_api = { git = "https://github.com/samuel-cavalcanti/rust_zmqRemoteApi", optional = true }
-
+coppeliasim_zmq_remote_api = { git = "https://github.com/samuel-cavalcanti/rust_zmqRemoteApi", optional = true }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.16"
@@ -23,4 +22,4 @@ default = ["serde", "lola"]
 
 serde = []
 lola = ["dep:rmp-serde"]
-coppelia = ["dep:zmq_remote_api"]
+coppelia = ["dep:coppeliasim_zmq_remote_api"]

--- a/nidhogg/src/backend/coppelia.rs
+++ b/nidhogg/src/backend/coppelia.rs
@@ -1,5 +1,5 @@
 use crate::{Error, NaoBackend, NaoControlMessage, NaoState, Result};
-use zmq_remote_api::{RemoteApiClient, RemoteApiClientParams};
+use coppeliasim_zmq_remote_api::{RemoteApiClient, RemoteApiClientParams};
 
 use super::ConnectWithRetry;
 


### PR DESCRIPTION
The coppelia crate has been renamed in its repository, which causes the `main` branch to no longer compile.

This PR switches to the new crate name.