### PR TITLE
Convert `read_lola_nao_state` to pub fn

### DIFF
--- a/nidhogg/Cargo.toml
+++ b/nidhogg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nidhogg"
-version = "0.4.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nidhogg/Cargo.toml
+++ b/nidhogg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nidhogg"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nidhogg/Cargo.toml
+++ b/nidhogg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nidhogg"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nidhogg/src/backend/lola.rs
+++ b/nidhogg/src/backend/lola.rs
@@ -149,7 +149,7 @@ impl ReadHardwareInfo for LolaBackend {
 
 impl LolaBackend {
     /// Read a [`LolaNaoState`] from the `LoLA` socket.
-    fn read_lola_nao_state<'a>(
+    pub fn read_lola_nao_state<'a>(
         &mut self,
         buf: &'a mut [u8; LOLA_BUFFER_SIZE],
     ) -> Result<LolaNaoState<'a>> {
@@ -501,7 +501,7 @@ impl FromLoLA<[f32; 3]> for Vector3<f32> {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct LolaNaoState<'a> {
+pub struct LolaNaoState<'a> {
     stiffness: [f32; 25],
     position: [f32; 25],
     temperature: [f32; 25],

--- a/nidhogg/src/backend/lola.rs
+++ b/nidhogg/src/backend/lola.rs
@@ -149,6 +149,11 @@ impl ReadHardwareInfo for LolaBackend {
 
 impl LolaBackend {
     /// Read a [`LolaNaoState`] from the `LoLA` socket.
+    ///
+    /// # Note
+    ///
+    /// This reads from the underlying `LoLA` unix socket, which consumes the message
+    /// sent by `LoLA`.
     pub fn read_lola_nao_state<'a>(
         &mut self,
         buf: &'a mut [u8; LOLA_BUFFER_SIZE],

--- a/nidhogg/src/backend/mod.rs
+++ b/nidhogg/src/backend/mod.rs
@@ -11,10 +11,7 @@ pub use coppelia::CoppeliaBackend;
 
 #[cfg(feature = "lola")]
 mod lola;
-pub use lola::LolaControlMsg;
-
-#[cfg(feature = "lola")]
-pub use lola::LolaBackend;
+pub use lola::{LolaBackend, LolaControlMsg, LolaNaoState};
 
 use std::any::type_name;
 use std::thread;


### PR DESCRIPTION
As `read_lola_nao_state` is required by nott to obtain NaoState for processing battery data, this function should be made public.